### PR TITLE
Use more appropriate license icons

### DIFF
--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -13,7 +13,7 @@
                     :href="project_url+'dashboard'"
                 >
                     <v-list-item-icon>
-                        <v-icon>mdi-github</v-icon>
+                        <v-icon>mdi-code-tags</v-icon>
                     </v-list-item-icon>
                     <v-list-item-content>
                         <v-list-item-title>Source code</v-list-item-title>

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -24,7 +24,7 @@
                     :href="project_url+'dashboard/blob/main/LICENSE'"
                 >
                     <v-list-item-icon>
-                        <v-icon>mdi-license</v-icon>
+                        <v-icon>mdi-copyright</v-icon>
                     </v-list-item-icon>
                     <v-list-item-content>
                         <v-list-item-title>License</v-list-item-title>


### PR DESCRIPTION
* s/mdi-license/mdi-copyright/g
* s/mdi-github/mdi-code-tags/g

These seem to be more widely used by other projects