### PR TITLE
Keep old built files

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -4,7 +4,7 @@ SLEEPDIARY_NAME=dashboard
 NEEDS_PORT=1
 
 cmd_build() {
-    yarn --frozen-lockfile && yarn build --dest docs
+    yarn --frozen-lockfile && yarn build --dest docs --no-clean
 }
 
 cmd_test() {


### PR DESCRIPTION
Deleting old files might break the user experience for e.g. people loading the page while an update goes through.